### PR TITLE
Clarify the Namespace type

### DIFF
--- a/samples/hybrid-connections/dotnet/simple-websocket/README.md
+++ b/samples/hybrid-connections/dotnet/simple-websocket/README.md
@@ -15,7 +15,7 @@ and then start the client with
 
 whereby the arguments are as follows:
 
-* [ns] - fully qualified domain name for the Service Bus namespace, eg. contoso.servicebus.windows.net
+* [ns] - fully qualified domain name for the Azure Relay namespace, eg. contoso.servicebus.windows.net
 * [hc] - name of a previously configured Hybrid Connection (see [main README](../../README.md))
 * [keyname] - name of a SAS rule that confers the required right(s). "Listen" is required for the 
 server, "Send" is required for the client. The default management rule confers both.


### PR DESCRIPTION
Service Bus Namespace is a different kind of artifact than Relay. HybridConnections are only allows in Azure Relay Namespaces not Service Bus Namespaces.

## Description
<!--
Please add an informative description that covers the changes made by the pull request.

If applicable, reference the bug/issue that this pull request fixes here.
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [n/a] If applicable, the code is properly documented.
- [n/a] The code builds without any errors.