### PR TITLE
Fix problems with server-side exceptions and adding headers to the response

### DIFF
--- a/samples/hybrid-connections/dotnet/aspnet/src/Microsoft.AspNetCore.Server.AzureRelay/MessagePump.cs
+++ b/samples/hybrid-connections/dotnet/aspnet/src/Microsoft.AspNetCore.Server.AzureRelay/MessagePump.cs
@@ -163,6 +163,13 @@ namespace Microsoft.Azure.Relay.AspNetCore
                         await _application.ProcessRequestAsync(context);
                         await featureContext.OnResponseStart();
                     }
+                    catch
+                    {
+                        // We haven't sent a response yet, try to send a 500 Internal Server Error
+                        requestContext.Response.Headers.Clear();
+                        SetFatalResponse(requestContext, (HttpStatusCode)500);
+                        throw;
+                    }
                     finally
                     {
                         await featureContext.OnCompleted();
@@ -174,9 +181,6 @@ namespace Microsoft.Azure.Relay.AspNetCore
                 {
                     LogHelper.LogException(_logger, "ProcessRequestAsync", ex);
                     _application.DisposeContext(context, ex);
-                        // We haven't sent a response yet, try to send a 500 Internal Server Error
-                        requestContext.Response.Headers.Clear();
-                        SetFatalResponse(requestContext, (HttpStatusCode)500);
                     
                 }
                 finally


### PR DESCRIPTION
## Description
This pull request aims to solve 2 problems I encountered while using the sample:
- When an exception is thrown in a controller, the client receives an empty 204 response instead of a 500; also an additional exception is thrown server-side because the response object has already been disposed. This fix for this is moving the code for returning the 500 response to an extra earlier catch block and then rethrowing the exception to the outer catch block.
- When adding headers to the response you also get an exception. The addition of the headers simply came too late. I changed this by having the headers be written directly into the response object instead of collecting them and copying them to the response later.
 
This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] If applicable, the code is properly documented.
- [X] The code builds without any errors.